### PR TITLE
Added API parameter handling for getOrganizations()

### DIFF
--- a/insightly.php
+++ b/insightly.php
@@ -492,8 +492,33 @@ class Insightly{
   }
 
   public function getOrganizations($options = null){
+    $ids = isset($options["ids"]) ? $options["ids"] : null;
+    $domain = isset($options["domain"]) ? $options["domain"] : null;
+    $tag = isset($options["tag"]) ? $options["tag"] : null;
+
     $request = $this->GET("/v2.1/Organisations");
+
+    // handle standard OData options
     $this->buildODataQuery($request, $options);
+
+    // handle other options
+    if($email != null){
+      $request->queryParam("domain", $domain);
+    }
+    if($tag != null){
+      $request->queryParam("tag", $tag);
+    }
+    if($ids != null){
+      $s = "";
+      foreach($ids as $key => $value){
+        if($key > 0){
+          $s = $s . ",";
+        }
+        $s = $s . $value;
+      }
+      $request->queryParam("ids", $s);
+    }
+
     return $request->asJSON();
   }
 


### PR DESCRIPTION
Please consider my pull request.

I needed access to search organizations by tag so I added the API parameters ids, domain and tag as per the API documentation. I followed the code pattern used in `getContacts()` and applied it to `getOrganizations()`.